### PR TITLE
magic R Script compatibility

### DIFF
--- a/R/fetch.R
+++ b/R/fetch.R
@@ -17,7 +17,7 @@
 #' df <- DomoR::fetch('4826e3fb-cd23-468d-9aff-96bf5b690247',
 #'   c('accountid', 'lastname', 'startdate'),
 #'   httr::progress())
-fetch <- function(id, columns = NULL, use.make.names=FALSE, guessEncoding=TRUE, ...) {
+fetch <- function(id, columns = NULL, use.make.names=FALSE, guessEncoding=TRUE, strip.white=FALSE, ...) {
 
   # check that required env variables exist
   if(!exists("customer", .domo_env) || !exists("auth.token", .domo_env)) {
@@ -59,7 +59,7 @@ fetch <- function(id, columns = NULL, use.make.names=FALSE, guessEncoding=TRUE, 
     }
   }
   
-  df <- httr::content(get_result,na=c('\\N'),encoding=guessEncodingValue, ...) # type="domo/csv"
+  df <- httr::content(get_result,na=c('\\N'),encoding=guessEncodingValue, trim_ws=strip.white, ...) # type="domo/csv"
 
   if(use.make.names){
     names(df) <- make.names(tolower(names(df)))

--- a/R/read.dataset.R
+++ b/R/read.dataset.R
@@ -1,0 +1,25 @@
+#' Read a dataset
+#'
+#' Retrieves a data set by name
+#' converts it to a data.frame and returns.
+#' Provides compatability with domomagic read.dataframe()
+#'
+#' @param name A data source name
+#' @param ... Additional options
+#' @return A \code{data.frame} built from the requested Domo data set
+#' @export
+#' @examples
+#' DomoR::init(Sys.getenv('DOMO_BASE_URL'), Sys.getenv('DEVELOPER_TOKEN'))
+#' df <- DomoR::read.dataset('TEST | Data')
+read.dataset <- function(name, strip.white=FALSE, ...) {
+
+  # check that required env variables exist
+  if(!exists("customer", .domo_env) || !exists("auth.token", .domo_env)) {
+    stop("Both a customer instance and token are required, please set with 'DomoR::init('customer', 'token')'")
+  }
+
+  id <- list_ds(name = name)['id']
+  df <- fetch(id,strip.white=strip.white, ...)
+
+  return(data.frame(df))
+}


### PR DESCRIPTION
To enable easy switching between using R/DomoR for development and Magic Script tiles for production:
1) Add read.dataset() that works like domomagic::read.dataset() 
2) Default fetch to no strip whitespaces to match domomagic::read.dataset() and the rest of Domo